### PR TITLE
:bug: Correctly encode image paths for src attribute

### DIFF
--- a/lib/image-editor.coffee
+++ b/lib/image-editor.coffee
@@ -52,7 +52,7 @@ class ImageEditor
   # Retrieves the URI of the image.
   #
   # Returns a {String}.
-  getURI: -> @getPath()
+  getURI: -> encodeURI(@getPath()).replace('#', '%23').replace('?', '%3F')
 
   # Retrieves the absolute path to the image.
   #

--- a/spec/image-editor-view-spec.coffee
+++ b/spec/image-editor-view-spec.coffee
@@ -93,3 +93,19 @@ describe "ImageEditorView", ->
 
     it "displays the size of the image", ->
       expect(imageSizeStatus.text()).toBe '10x10'
+
+  describe "when special characters are used in the file name", ->
+    describe "when '?' exists in the file name", ->
+      it "is replaced with %3F", ->
+        newEditor = new ImageEditor('/test/file/?.png')
+        expect(newEditor.getURI()).toBe('/test/file/%3F.png')
+
+    describe "when '#' exists in the file name", ->
+      it "is replaced with %23", ->
+        newEditor = new ImageEditor('/test/file/#.png')
+        expect(newEditor.getURI()).toBe('/test/file/%23.png')
+
+    describe "when '%2F' exists in the file name", ->
+      it "should properly encode the %", ->
+        newEditor = new ImageEditor('/test/file/%2F.png')
+        expect(newEditor.getURI()).toBe('/test/file/%252F.png')


### PR DESCRIPTION
Images such as '?.png', '#.png' and '%2F.png' all fail loading due to not being
correctly encoded before passing off to the img src attribute. The fix for this
is to encode the URI using encodeURI and then manually encode '?' and '#' since
file paths cannot have a hash fragments or query string.

Fixes #38