### PR TITLE
Defer jQuery initialization

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,18 +1,30 @@
 path = require 'path'
 _ = require 'underscore-plus'
 ImageEditor = require './image-editor'
+{CompositeDisposable} = require 'atom'
 
 module.exports =
   activate: ->
-    @openerDisposable = atom.workspace.addOpener(openURI)
+    @statusViewAttached = false
+    @disposables = new CompositeDisposable
+    @disposables.add atom.workspace.addOpener(openURI)
+    @disposables.add atom.workspace.onDidChangeActivePaneItem => @attachImageEditorStatusView()
 
   deactivate: ->
-    @openerDisposable.dispose()
+    @disposables.dispose()
 
-  consumeStatusBar: (statusBar) ->
+  consumeStatusBar: (@statusBar) -> @attachImageEditorStatusView()
+
+  attachImageEditorStatusView: ->
+    return if @statusViewAttached
+    return unless @statusBar?
+    return unless atom.workspace.getActivePaneItem() instanceof ImageEditor
+
     ImageEditorStatusView = require './image-editor-status-view'
-    view = new ImageEditorStatusView(statusBar)
+    view = new ImageEditorStatusView(@statusBar)
     view.attach()
+
+    @statusViewAttached = true
 
 # Files with these extensions will be opened as images
 imageExtensions = ['.gif', '.ico', '.jpeg', '.jpg', '.png', '.webp']


### PR DESCRIPTION
In conjunction with https://github.com/atom/spell-check/pull/98, this is a quick win that allows us to make startup 50ms faster by deferring jQuery initialization until the last possible moment (i.e. not during startup).