### PR TITLE
Don't encode URI multiple times

### DIFF
--- a/lib/image-editor-view.coffee
+++ b/lib/image-editor-view.coffee
@@ -75,7 +75,7 @@ class ImageEditorView extends ScrollView
     @disposables.dispose()
 
   updateImageURI: ->
-    @image.attr('src', "#{@editor.getURI()}?time=#{Date.now()}")
+    @image.attr('src', "#{@editor.getEncodedURI()}?time=#{Date.now()}")
 
   # Retrieves this view's pane.
   #

--- a/lib/image-editor.coffee
+++ b/lib/image-editor.coffee
@@ -15,7 +15,6 @@ class ImageEditor
 
   constructor: (filePath) ->
     @file = new File(filePath)
-    @uri = "file://" + encodeURI(filePath.replace(/\\/g, '/')).replace(/#/g, '%23').replace(/\?/g, '%3F')
     @subscriptions = new CompositeDisposable()
     @emitter = new Emitter
 
@@ -57,15 +56,23 @@ class ImageEditor
     else
       'untitled'
 
-  # Retrieves the URI of the image.
-  #
-  # Returns a {String}.
-  getURI: -> @uri
-
   # Retrieves the absolute path to the image.
   #
   # Returns a {String} path.
-  getPath: -> @file.getPath()
+  getPath: ->
+    @file.getPath()
+
+  # Retrieves the URI of the image.
+  #
+  # Returns a {String}.
+  getURI: ->
+    @getPath()
+
+  # Retrieves the encoded URI of the image.
+  #
+  # Returns a {String}.
+  getEncodedURI: ->
+    "file://" + encodeURI(@getPath().replace(/\\/g, '/')).replace(/#/g, '%23').replace(/\?/g, '%3F')
 
   # Compares two {ImageEditor}s to determine equality.
   #

--- a/spec/image-editor-spec.coffee
+++ b/spec/image-editor-spec.coffee
@@ -73,3 +73,28 @@ describe "ImageEditor", ->
         item.onDidTerminatePendingState pendingSpy
         item.terminatePendingState()
         expect(pendingSpy).not.toHaveBeenCalled()
+
+  describe "when the image gets reopened", ->
+    beforeEach ->
+      waitsForPromise ->
+        atom.packages.activatePackage('image-view')
+
+    it "should not change the URI between each reopen", ->
+      uri = null
+
+      runs ->
+        atom.workspace.open(path.join(__dirname, 'fixtures', 'binary-file.png'))
+
+      waitsFor ->
+        atom.workspace.getActivePaneItem() instanceof ImageEditor
+
+      runs ->
+        uri = atom.workspace.getActivePaneItem().getURI()
+        atom.workspace.destroyActivePaneItem()
+        atom.workspace.reopenItem()
+
+      waitsFor ->
+        atom.workspace.getActivePaneItem() instanceof ImageEditor
+
+      runs ->
+        expect(atom.workspace.getActivePaneItem().getURI()).toBe uri

--- a/spec/image-editor-view-spec.coffee
+++ b/spec/image-editor-view-spec.coffee
@@ -105,22 +105,22 @@ describe "ImageEditorView", ->
     describe "when '?' exists in the file name", ->
       it "is replaced with %3F", ->
         newEditor = new ImageEditor('/test/file/?.png')
-        expect(newEditor.getURI()).toBe('file:///test/file/%3F.png')
+        expect(newEditor.getEncodedURI()).toBe('file:///test/file/%3F.png')
 
     describe "when '#' exists in the file name", ->
       it "is replaced with %23", ->
         newEditor = new ImageEditor('/test/file/#.png')
-        expect(newEditor.getURI()).toBe('file:///test/file/%23.png')
+        expect(newEditor.getEncodedURI()).toBe('file:///test/file/%23.png')
 
     describe "when '%2F' exists in the file name", ->
       it "should properly encode the %", ->
         newEditor = new ImageEditor('/test/file/%2F.png')
-        expect(newEditor.getURI()).toBe('file:///test/file/%252F.png')
+        expect(newEditor.getEncodedURI()).toBe('file:///test/file/%252F.png')
 
     describe "when multiple special characters exist in the file name", ->
       it "are all replaced with escaped characters", ->
         newEditor = new ImageEditor('/test/file/a?#b#?.png')
-        expect(newEditor.getURI()).toBe('file:///test/file/a%3F%23b%23%3F.png')
+        expect(newEditor.getEncodedURI()).toBe('file:///test/file/a%3F%23b%23%3F.png')
 
   describe "when multiple images are opened at the same time", ->
     beforeEach ->


### PR DESCRIPTION
In the current implementation `getURI` returns the encoded path which is used by the image view to display the image. Because the URI returned from `getURI` is encoded in the constructor this doesn't work with things like reopen closed tab which uses the URI to open the same item. As this causes the already encoded URI to get encoded again.

This PR changes this to use the file path as URI and move the encoded URI to a separate function.

Closes https://github.com/atom/image-view/issues/53 and Closes https://github.com/atom/image-view/issues/48
This also fixes reloading updated/moved/renamed images for me, which currently doesn't have an open issue. If I open an image in Atom and rename that file from the file explorer the tree-view and tab title updates but the image shown in the image view is a broken image.

This is my first PR ever, first time using git ever, first time writing coffeescript ever. I have no idea what I am doing.