### PR TITLE
Show image size in status bar

### DIFF
--- a/lib/image-editor-status-view.coffee
+++ b/lib/image-editor-status-view.coffee
@@ -1,6 +1,7 @@
 {$, View} = require 'atom-space-pen-views'
 {CompositeDisposable} = require 'atom'
 ImageEditor = require './image-editor'
+bytes = require 'bytes'
 
 module.exports =
 class ImageEditorStatusView extends View
@@ -21,7 +22,7 @@ class ImageEditorStatusView extends View
     @updateImageSize()
 
   getImageSize: ({originalHeight, originalWidth, imageSize}) ->
-    @imageSizeStatus.text("#{originalWidth}x#{originalHeight} #{imageSize}").show()
+    @imageSizeStatus.text("#{originalWidth}x#{originalHeight} #{bytes(imageSize)}").show()
 
   updateImageSize: ->
     @imageLoadDisposable?.dispose()

--- a/lib/image-editor-status-view.coffee
+++ b/lib/image-editor-status-view.coffee
@@ -20,8 +20,8 @@ class ImageEditorStatusView extends View
   attached: ->
     @updateImageSize()
 
-  getImageSize: ({originalHeight, originalWidth}) ->
-    @imageSizeStatus.text("#{originalWidth}x#{originalHeight}").show()
+  getImageSize: ({originalHeight, originalWidth, imageSize}) ->
+    @imageSizeStatus.text("#{originalWidth}x#{originalHeight} #{imageSize}").show()
 
   updateImageSize: ->
     @imageLoadDisposable?.dispose()

--- a/lib/image-editor-view.coffee
+++ b/lib/image-editor-view.coffee
@@ -1,5 +1,6 @@
 _ = require 'underscore-plus'
 path = require 'path'
+fs = require 'fs-plus'
 {$, ScrollView} = require 'atom-space-pen-views'
 {Emitter, CompositeDisposable} = require 'atom'
 
@@ -29,6 +30,7 @@ class ImageEditorView extends ScrollView
   initialize: (@editor) ->
     super
     @emitter = new Emitter
+    @imageSize = fs.statSync(@editor.getPath())["size"]
 
   attached: ->
     @disposables = new CompositeDisposable

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "atom-space-pen-views": "^2.0.0",
     "fs-plus": "^2.0.0",
-    "underscore-plus": "^1.0.0"
+    "underscore-plus": "^1.0.0",
+    "bytes": "^2.4.0"
   },
   "consumedServices": {
     "status-bar": {

--- a/spec/image-editor-view-spec.coffee
+++ b/spec/image-editor-view-spec.coffee
@@ -98,7 +98,7 @@ describe "ImageEditorView", ->
         expect(imageSizeStatus).toExist()
 
     it "displays the size of the image", ->
-      expect(imageSizeStatus.text()).toBe '10x10'
+      expect(imageSizeStatus.text()).toBe '10x10 392B'
 
   describe "when special characters are used in the file name", ->
     describe "when '?' exists in the file name", ->


### PR DESCRIPTION
Implements https://github.com/atom/image-view/issues/51

Looks like this:
![double pending byte sizes](https://cloud.githubusercontent.com/assets/1058982/17994552/f865ea32-6b59-11e6-9968-ffa37e93b805.PNG)
![binary file bytes size](https://cloud.githubusercontent.com/assets/1058982/17994553/fc1674e4-6b59-11e6-8f3f-3c4f13f7f7ce.PNG)
