### PR TITLE
Confirm pending tabs by double clicking on them

### DIFF
--- a/spec/image-editor-spec.coffee
+++ b/spec/image-editor-spec.coffee
@@ -35,3 +35,41 @@ describe "ImageEditor", ->
 
       runs ->
         expect(atom.workspace.getActivePaneItem() instanceof ImageEditor).toBe false
+
+  describe "::onDidTerminatePendingState", ->
+    item = null
+    pendingSpy = null
+
+    beforeEach ->
+      pendingSpy = jasmine.createSpy("onDidTerminatePendingState")
+
+      waitsForPromise ->
+        atom.packages.activatePackage('image-view')
+
+    it "is called when pending state gets terminated for the active ImageEditor", ->
+      runs ->
+        atom.workspace.open(path.join(__dirname, 'fixtures', 'binary-file.png'), pending: true)
+
+      waitsFor ->
+        atom.workspace.getActivePane().getPendingItem() instanceof ImageEditor
+
+      runs ->
+        item = atom.workspace.getActivePane().getPendingItem()
+        expect(item.getTitle()).toBe 'binary-file.png'
+        item.onDidTerminatePendingState pendingSpy
+        item.terminatePendingState()
+        expect(pendingSpy).toHaveBeenCalled()
+
+    it "is not called when the ImageEditor is not pending", ->
+      runs ->
+        atom.workspace.open(path.join(__dirname, 'fixtures', 'binary-file.png'), pending: false)
+
+      waitsFor ->
+        atom.workspace.getActivePaneItem() instanceof ImageEditor
+
+      runs ->
+        item = atom.workspace.getActivePaneItem()
+        expect(item.getTitle()).toBe 'binary-file.png'
+        item.onDidTerminatePendingState pendingSpy
+        item.terminatePendingState()
+        expect(pendingSpy).not.toHaveBeenCalled()


### PR DESCRIPTION
Fixes https://github.com/atom/image-view/issues/65

Seems the event is not fired when opening by double clicking in the tree-view. This is because the URI has changed and will be fixed by https://github.com/atom/image-view/pull/66.
The `atom.workspace.open` function checks for a pending pane item with the same URI to clear pending state on and fire the event. Because the URI was encoded since it was opened the comparison is between encoded and not encoded URI. Which will not be found https://github.com/atom/atom/blob/master/src/workspace.coffee#L502