### PR TITLE
Add an option to change default image background style

### DIFF
--- a/lib/image-editor-view.coffee
+++ b/lib/image-editor-view.coffee
@@ -22,7 +22,7 @@ class ImageEditorView extends ScrollView
         @div class: 'image-controls-group btn-group', =>
           @button class: 'btn', outlet: 'zoomToFitButton', 'Zoom to fit'
 
-      @div class: 'image-container', background: 'white', outlet: 'imageContainer', =>
+      @div class: 'image-container', background: 'transparent', outlet: 'imageContainer', =>
         @img outlet: 'image'
 
   initialize: (@editor) ->
@@ -50,6 +50,9 @@ class ImageEditorView extends ScrollView
       @originalHeight = @image.prop('naturalHeight')
       @originalWidth = @image.prop('naturalWidth')
       @loaded = true
+      @backgroundStyle = atom.config.get 'image-view.defaultImageBackgroundStyle'
+      unless @backgroundStyle is 'transparent'
+        @changeBackground @backgroundStyle
       @image.show()
       @emitter.emit 'did-load'
 
@@ -59,7 +62,10 @@ class ImageEditorView extends ScrollView
 
     if @getPane()
       @imageControls.find('a').on 'click', (e) =>
-        @changeBackground $(e.target).attr 'value'
+        @backgroundStyle = $(e.target).attr 'value'
+        @changeBackground @backgroundStyle
+        if atom.config.get 'image-view.changeDefaultOnBackgroundSelection'
+          atom.config.set 'image-view.defaultImageBackgroundStyle', @backgroundStyle
 
     @zoomInButton.on 'click', => @zoomIn()
     @zoomOutButton.on 'click', => @zoomOut()

--- a/package.json
+++ b/package.json
@@ -23,5 +23,24 @@
   },
   "devDependencies": {
     "coffeelint": "^1.9.7"
+  },
+  "configSchema": {
+    "defaultImageBackgroundStyle": {
+      "title": "Default Image Background Style",
+      "description": "Choose the default image background style used when opening an image.",
+      "type": "string",
+      "default": "white",
+      "enum": [
+        {"value": "white", "description": "White Transparent"},
+        {"value": "black", "description": "Black Transparent"},
+        {"value": "transparent", "description": "Transparent"}
+      ]
+    },
+    "changeDefaultOnBackgroundSelection": {
+      "title": "Change Background Style Default on Selection",
+      "description": "When selecting a background style, set the selection as the default.",
+      "type": "boolean",
+      "default": "true"
+    }
   }
 }


### PR DESCRIPTION
Creates two new settings for default background styles:
- A switch to make your most recent selection the default when opening new images (ON by default)
- A drop-down to select the default background style

Also changes the default image view area background to transparent, to prevent a white flash on the screen before the image loads.

![image-view-improvement](https://cloud.githubusercontent.com/assets/531798/20719306/61fb685c-b653-11e6-8de6-b5ce0c36c0c5.png)

Fixes #57 