### PR TITLE
Add a config for the background style

### DIFF
--- a/lib/image-editor-view.coffee
+++ b/lib/image-editor-view.coffee
@@ -64,8 +64,7 @@ class ImageEditorView extends ScrollView
       @imageControls.find('a').on 'click', (e) =>
         @backgroundStyle = $(e.target).attr 'value'
         @changeBackground @backgroundStyle
-        if atom.config.get 'image-view.changeDefaultOnBackgroundSelection'
-          atom.config.set 'image-view.defaultImageBackgroundStyle', @backgroundStyle
+        atom.config.set 'image-view.defaultImageBackgroundStyle', @backgroundStyle
 
     @zoomInButton.on 'click', => @zoomIn()
     @zoomOutButton.on 'click', => @zoomOut()

--- a/lib/image-editor-view.coffee
+++ b/lib/image-editor-view.coffee
@@ -50,7 +50,7 @@ class ImageEditorView extends ScrollView
       @originalHeight = @image.prop('naturalHeight')
       @originalWidth = @image.prop('naturalWidth')
       @loaded = true
-      @backgroundStyle = atom.config.get 'image-view.defaultImageBackgroundStyle'
+      @backgroundStyle = atom.config.get 'image-view.backgroundStyle'
       unless @backgroundStyle is 'transparent'
         @changeBackground @backgroundStyle
       @image.show()
@@ -64,7 +64,7 @@ class ImageEditorView extends ScrollView
       @imageControls.find('a').on 'click', (e) =>
         @backgroundStyle = $(e.target).attr 'value'
         @changeBackground @backgroundStyle
-        atom.config.set 'image-view.defaultImageBackgroundStyle', @backgroundStyle
+        atom.config.set 'image-view.backgroundStyle', @backgroundStyle
 
     @zoomInButton.on 'click', => @zoomIn()
     @zoomOutButton.on 'click', => @zoomOut()

--- a/lib/image-editor-view.coffee
+++ b/lib/image-editor-view.coffee
@@ -22,7 +22,7 @@ class ImageEditorView extends ScrollView
         @div class: 'image-controls-group btn-group', =>
           @button class: 'btn', outlet: 'zoomToFitButton', 'Zoom to fit'
 
-      @div class: 'image-container', background: 'white', outlet: 'imageContainer', =>
+      @div class: 'image-container', background: 'transparent', outlet: 'imageContainer', =>
         @img outlet: 'image'
 
   initialize: (@editor) ->
@@ -50,6 +50,9 @@ class ImageEditorView extends ScrollView
       @originalHeight = @image.prop('naturalHeight')
       @originalWidth = @image.prop('naturalWidth')
       @loaded = true
+      @backgroundStyle = atom.config.get 'image-view.defaultImageBackgroundStyle'
+      unless @backgroundStyle is 'transparent'
+        @changeBackground @backgroundStyle
       @image.show()
       @emitter.emit 'did-load'
 
@@ -59,7 +62,10 @@ class ImageEditorView extends ScrollView
 
     if @getPane()
       @imageControls.find('a').on 'click', (e) =>
-        @changeBackground $(e.target).attr 'value'
+        @backgroundStyle = $(e.target).attr 'value'
+        @changeBackground @backgroundStyle
+        if atom.config.get 'image-view.changeDefaultOnBackgroundSelection'
+          atom.config.set 'image-view.defaultImageBackgroundStyle', @backgroundStyle
 
     @zoomInButton.on 'click', => @zoomIn()
     @zoomOutButton.on 'click', => @zoomOut()

--- a/lib/image-editor-view.coffee
+++ b/lib/image-editor-view.coffee
@@ -62,17 +62,13 @@ class ImageEditorView extends ScrollView
 
     if @getPane()
       @imageControls.find('a').on 'click', (e) =>
-        @backgroundStyle = $(e.target).attr 'value'
-        @changeBackground @backgroundStyle
-        atom.config.set 'image-view.backgroundStyle', @backgroundStyle
-
+        atom.config.set 'image-view.backgroundStyle', $(e.target).attr 'value'
       @imageControls.find('a').on 'mouseover', (e) =>
-        @backgroundStyle = $(e.target).attr 'value'
-        @changeBackground @backgroundStyle
-
+        @changeBackground $(e.target).attr 'value'
       @imageControls.find('a').on 'mouseout', (e) =>
-        @backgroundStyle = atom.config.get 'image-view.backgroundStyle'
-        @changeBackground @backgroundStyle
+        @changeBackground atom.config.get 'image-view.backgroundStyle'
+    @disposables.add atom.config.observe 'image-view.backgroundStyle', (backgroundStyle) =>
+      @changeBackground backgroundStyle
 
     @zoomInButton.on 'click', => @zoomIn()
     @zoomOutButton.on 'click', => @zoomOut()

--- a/lib/image-editor-view.coffee
+++ b/lib/image-editor-view.coffee
@@ -66,6 +66,14 @@ class ImageEditorView extends ScrollView
         @changeBackground @backgroundStyle
         atom.config.set 'image-view.backgroundStyle', @backgroundStyle
 
+      @imageControls.find('a').on 'mouseover', (e) =>
+        @backgroundStyle = $(e.target).attr 'value'
+        @changeBackground @backgroundStyle
+
+      @imageControls.find('a').on 'mouseout', (e) =>
+        @backgroundStyle = atom.config.get 'image-view.backgroundStyle'
+        @changeBackground @backgroundStyle
+
     @zoomInButton.on 'click', => @zoomIn()
     @zoomOutButton.on 'click', => @zoomOut()
     @resetZoomButton.on 'click', => @resetZoom()

--- a/package.json
+++ b/package.json
@@ -35,12 +35,6 @@
         {"value": "black", "description": "Black Transparent"},
         {"value": "transparent", "description": "Transparent"}
       ]
-    },
-    "changeDefaultOnBackgroundSelection": {
-      "title": "Change Background Style Default on Selection",
-      "description": "When selecting a background style, set the selection as the default.",
-      "type": "boolean",
-      "default": "true"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,5 +23,24 @@
   },
   "devDependencies": {
     "coffeelint": "^1.9.7"
+  },
+  "configSchema": {
+    "defaultImageBackgroundStyle": {
+      "title": "Default Image Background Style",
+      "description": "Choose the default image background style used when opening an image.",
+      "type": "string",
+      "default": "white",
+      "enum": [
+        {"value": "white", "description": "White Transparent"},
+        {"value": "black", "description": "Black Transparent"},
+        {"value": "transparent", "description": "Transparent"}
+      ]
+    },
+    "changeDefaultOnBackgroundSelection": {
+      "title": "Change Background Style Default on Selection",
+      "description": "When selecting a background style, set the selection as the default.",
+      "type": "boolean",
+      "default": "true"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
       "title": "Background Style",
       "description": "Choose the background style used when opening an image.",
       "type": "string",
-      "default": "white",
+      "default": "transparent",
       "enum": [
         {"value": "white", "description": "White Transparent"},
         {"value": "black", "description": "Black Transparent"},

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "coffeelint": "^1.9.7"
   },
   "configSchema": {
-    "defaultImageBackgroundStyle": {
-      "title": "Default Image Background Style",
-      "description": "Choose the default image background style used when opening an image.",
+    "backgroundStyle": {
+      "title": "Background Style",
+      "description": "Choose the background style used when opening an image.",
       "type": "string",
       "default": "white",
       "enum": [

--- a/spec/image-editor-view-spec.coffee
+++ b/spec/image-editor-view-spec.coffee
@@ -69,6 +69,16 @@ describe "ImageEditorView", ->
       view.adjustSize(0)
       expect(view.resetZoomButton.text()).toBe '1%'
 
+  describe "when changing the background style", ->
+    it "has a transparent background by default", ->
+      expect(view.imageContainer.attr('background')).toBe 'transparent'
+    it "changes to a white background", ->
+      atom.config.set('image-view.backgroundStyle', 'white')
+      expect(view.imageContainer.attr('background')).toBe 'white'
+    it "changes to a black background", ->
+      atom.config.set('image-view.backgroundStyle', 'black')
+      expect(view.imageContainer.attr('background')).toBe 'black'
+
   describe "ImageEditorStatusView", ->
     [imageSizeStatus] = []
 


### PR DESCRIPTION
### Description of the Change

This PR:

- Changes to `transparent` as **new** default
- Adds a config for the background style
- Allows to change the config with the background picker in the toolbar
- Allows to **temporarily** change the background by just hovering over the background picker

![hover](https://cloud.githubusercontent.com/assets/378023/22548177/9a13b01a-e988-11e6-9b86-09de456efd6c.gif)

### Alternate Designs

There is a similar PR #75 with an extra config and without hover preview.

### Benefits

1. It lets you quickly change the background for many images (changes config).
2. It lets you quickly change the background for an image but not for all the other ones (hover).

### Possible Drawbacks

This PR also changes the default from `white` to `transparent` and might upset some. But it should be not a too big issue since you can change it back and I think using transparent is the better default, especially for dark themes.

### Applicable Issues

- This continues from #75 with [Option B](https://github.com/atom/image-view/pull/75#issuecomment-264360568)
- Closes #57