### PR TITLE
Use transparent background as default

### DIFF
--- a/lib/image-editor-view.js
+++ b/lib/image-editor-view.js
@@ -116,7 +116,7 @@ export default class ImageEditorView {
           </div>
         </div>
 
-        <div className='image-container' background='white' ref='imageContainer'>
+        <div className='image-container' ref='imageContainer'>
           <img ref='image'></img>
         </div>
       </div>


### PR DESCRIPTION
### Description of the Change

This changes the default background to **transparent**.

![image](https://cloud.githubusercontent.com/assets/378023/26613367/58dae89c-45f5-11e7-8bac-1a9288b5c193.png)

### Alternate Designs

There is a WIP [PR](https://github.com/atom/image-view/pull/80) that would update the config.

### Benefits

Integrates better with themes, especially dark ones.

### Possible Drawbacks

Some people might prefer white. Note: Due to some change, the background has been transparent for a while and there hasn't been any complaints.

### Applicable Issues

Replaces #80 with a simpler version.
