### PR TITLE
Use zoom steps instead of factor for adjusting image size

### DIFF
--- a/lib/image-editor-view.js
+++ b/lib/image-editor-view.js
@@ -14,7 +14,8 @@ export default class ImageEditorView {
     this.imageSize = fs.statSync(this.editor.getPath()).size
     this.loaded = false
     this.mode = 'zoom-to-fit'
-    this.percentage = 1.0
+    this.percentageStep = 4
+    this.steps = [0.1, 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 2, 3, 4, 5, 7.5, 10]
     etch.initialize(this)
 
     this.refs.image.style.display = 'none'
@@ -130,12 +131,14 @@ export default class ImageEditorView {
 
   // Zooms the image out by 25%.
   zoomOut () {
-    this.adjustSize(-0.25)
+    this.percentageStep = Math.max(0, --this.percentageStep)
+    this.adjustSize(this.percentageStep)
   }
 
   // Zooms the image in by 25%.
   zoomIn () {
-    this.adjustSize(0.25)
+    this.percentageStep = Math.min(this.steps.length - 1, ++this.percentageStep)
+    this.adjustSize(this.percentageStep)
   }
 
   // Zooms the image to its normal width and height.
@@ -150,7 +153,7 @@ export default class ImageEditorView {
     this.refs.image.style.width = this.originalWidth + 'px'
     this.refs.image.style.height = this.originalHeight + 'px'
     this.refs.resetZoomButton.textContent = '100%'
-    this.percentage = 1.0
+    this.percentageStep = 4
   }
 
   // Zooms to fit the image, doesn't scale beyond actual size
@@ -165,13 +168,13 @@ export default class ImageEditorView {
     this.refs.image.style.width = ''
     this.refs.image.style.height = ''
     this.refs.resetZoomButton.textContent = 'Auto'
-    this.percentage = 1.0
+    this.percentageStep = 4
   }
 
   // Adjust the size of the image by the given multiplying factor.
   //
   // factor - A {Number} to multiply against the current size.
-  adjustSize (factor) {
+  adjustSize (percentageStep) {
     if (!this.loaded || this.element.offsetHeight === 0) {
       return
     }
@@ -184,10 +187,9 @@ export default class ImageEditorView {
       this.mode = 'zoom-manual'
     }
 
-    this.percentage += factor
-
-    const newWidth = this.originalWidth * this.percentage
-    const newHeight = this.originalHeight * this.percentage
+    const factor = this.steps[percentageStep]
+    const newWidth = this.originalWidth * factor
+    const newHeight = this.originalHeight * factor
     const percent = Math.max(1, Math.round((newWidth / this.originalWidth) * 100))
 
     // Switch to pixelated rendering when image is bigger than 200%

--- a/lib/image-editor-view.js
+++ b/lib/image-editor-view.js
@@ -14,6 +14,7 @@ export default class ImageEditorView {
     this.imageSize = fs.statSync(this.editor.getPath()).size
     this.loaded = false
     this.mode = 'zoom-to-fit'
+    this.percentage = 1.0
     etch.initialize(this)
 
     this.refs.image.style.display = 'none'
@@ -129,12 +130,12 @@ export default class ImageEditorView {
 
   // Zooms the image out by 25%.
   zoomOut () {
-    this.adjustSize(0.75)
+    this.adjustSize(-0.25)
   }
 
   // Zooms the image in by 25%.
   zoomIn () {
-    this.adjustSize(1.25)
+    this.adjustSize(0.25)
   }
 
   // Zooms the image to its normal width and height.
@@ -149,6 +150,7 @@ export default class ImageEditorView {
     this.refs.image.style.width = this.originalWidth + 'px'
     this.refs.image.style.height = this.originalHeight + 'px'
     this.refs.resetZoomButton.textContent = '100%'
+    this.percentage = 1.0
   }
 
   // Zooms to fit the image, doesn't scale beyond actual size
@@ -181,8 +183,10 @@ export default class ImageEditorView {
       this.mode = 'zoom-manual'
     }
 
-    const newWidth = this.refs.image.offsetWidth * factor
-    const newHeight = this.refs.image.offsetHeight * factor
+    this.percentage += factor
+
+    const newWidth = this.originalWidth * this.percentage
+    const newHeight = this.originalHeight * this.percentage
     const percent = Math.max(1, Math.round((newWidth / this.originalWidth) * 100))
 
     // Switch to pixelated rendering when image is bigger than 200%

--- a/lib/image-editor-view.js
+++ b/lib/image-editor-view.js
@@ -165,6 +165,7 @@ export default class ImageEditorView {
     this.refs.image.style.width = ''
     this.refs.image.style.height = ''
     this.refs.resetZoomButton.textContent = 'Auto'
+    this.percentage = 1.0
   }
 
   // Adjust the size of the image by the given multiplying factor.

--- a/spec/image-editor-view-spec.coffee
+++ b/spec/image-editor-view-spec.coffee
@@ -65,7 +65,7 @@ describe "ImageEditorView", ->
 
   describe ".adjustSize(factor)", ->
     it "does not allow a zoom percentage lower than 1%", ->
-      view.adjustSize(0)
+      view.adjustSize(-view.percentage)
       expect(view.refs.resetZoomButton.textContent).toBe '1%'
 
   describe "ImageEditorStatusView", ->

--- a/spec/image-editor-view-spec.coffee
+++ b/spec/image-editor-view-spec.coffee
@@ -64,9 +64,9 @@ describe "ImageEditorView", ->
       expect(view.refs.image.offsetHeight).toBe 10
 
   describe ".adjustSize(factor)", ->
-    it "does not allow a zoom percentage lower than 1%", ->
-      view.adjustSize(-view.percentage)
-      expect(view.refs.resetZoomButton.textContent).toBe '1%'
+    it "does not allow a zoom percentage lower than 10%", ->
+      view.adjustSize(0)
+      expect(view.refs.resetZoomButton.textContent).toBe '10%'
 
   describe "ImageEditorStatusView", ->
     [imageSizeStatus] = []


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Instead of factor that the width is constantly multiplied with, it now uses steady steps on a percentage. This percentage is thus increased/decreased by the same steps and used to calculate the new width.

### Alternate Designs

The `adjustSize` function now takes the step as argument. I tried to calculate the correct factor to remain API compatible with the previous version, but that ran into other problems with `NaN` and `zoom-to-fit`.

### Benefits

Users now have solid steps again, with percentages that make sense.

### Possible Drawbacks

If other packages used the `adjustSize` function, they might run into problems, but I doubt it.

### Applicable Issues

Fixes #123 
Fixes #59 
