### PR TITLE
Close image view if file is deleted externally

### DIFF
--- a/lib/image-editor-status-view.js
+++ b/lib/image-editor-status-view.js
@@ -2,6 +2,7 @@
 
 import {CompositeDisposable} from 'atom'
 import ImageEditor from './image-editor'
+import ImageEditorView from './image-editor-view'
 import bytes from 'bytes'
 
 export default class ImageEditorStatusView {
@@ -42,7 +43,7 @@ export default class ImageEditorStatusView {
     }
 
     const editor = atom.workspace.getActivePaneItem()
-    if (editor instanceof ImageEditor) {
+    if (editor instanceof ImageEditor && editor.view instanceof ImageEditorView) {
       this.editorView = editor.view
       if (this.editorView.loaded) {
         this.getImageSize(this.editorView)

--- a/lib/image-editor.js
+++ b/lib/image-editor.js
@@ -17,12 +17,16 @@ export default class ImageEditor {
 
   constructor (filePath) {
     this.file = new File(filePath)
-    this.file.onDidDelete(() => {
-      this.subscriptions.dispose()
-      const pane = atom.workspace.paneForURI(filePath)
-      pane.destroyItem(pane.itemForURI(filePath))
-    })
     this.subscriptions = new CompositeDisposable()
+    this.subscriptions.add(this.file.onDidDelete(() => {
+      const pane = atom.workspace.paneForURI(filePath)
+      try {
+        pane.destroyItem(pane.itemForURI(filePath))
+      } catch (e) {
+        console.warn(`Could not destroy pane after external file was deleted: ${e}`)
+      }
+      this.subscriptions.dispose()
+    }))
     this.emitter = new Emitter()
   }
 
@@ -35,6 +39,7 @@ export default class ImageEditor {
       try {
         this.editorView = new ImageEditorView(this)
       } catch (e) {
+        console.warn(`Could not create ImageEditorView. This can be intentional in the event of an image file being deleted by an external program.`)
         return
       }
     }

--- a/lib/image-editor.js
+++ b/lib/image-editor.js
@@ -17,17 +17,26 @@ export default class ImageEditor {
 
   constructor (filePath) {
     this.file = new File(filePath)
+    this.file.onDidDelete(() => {
+      this.subscriptions.dispose()
+      const pane = atom.workspace.paneForURI(filePath)
+      pane.destroyItem(pane.itemForURI(filePath))
+    })
     this.subscriptions = new CompositeDisposable()
     this.emitter = new Emitter()
   }
 
   get element () {
-    return this.view.element
+    return this.view && this.view.element || document.createElement('div')
   }
 
   get view () {
     if (!this.editorView) {
-      this.editorView = new ImageEditorView(this)
+      try {
+        this.editorView = new ImageEditorView(this)
+      } catch (e) {
+        return
+      }
     }
     return this.editorView
   }


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Whenever an image was deleted externally, it threw an exception. Now, the pane is destroyed instead.

Note that I had to mimic the `get element()`, because destroying a panel item was actually retrieving the element again. E.g. `pane.destroyItem` asks for the element to be disposed. This is somewhat of a hack, but else I had to touch Atom core code to fix this loophole, if it could be fixed at all.

### Alternate Designs

You could add a placeholder message saying "Image has been deleted", but in #74 the proposed solution was to close the pane.

### Benefits

No more exceptions are thrown and a lot less issues opened on this repository :smile: 

### Possible Drawbacks

I don't know

### Applicable Issues

Fixes #74
