### PR TITLE
Update status bar when image is reloaded

### DIFF
--- a/lib/image-editor-status-view.js
+++ b/lib/image-editor-status-view.js
@@ -48,11 +48,14 @@ export default class ImageEditorStatusView {
         this.getImageSize(this.editorView)
       }
 
-      this.imageLoadDisposable = this.editorView.onDidLoad(() => {
+      this.imageLoadCompositeDisposable = new CompositeDisposable()
+      const callback = () => {
         if (editor === atom.workspace.getActivePaneItem()) {
           this.getImageSize(this.editorView)
         }
-      })
+      }
+      this.imageLoadCompositeDisposable.add(this.editorView.onDidLoad(callback))
+      this.imageLoadCompositeDisposable.add(this.editorView.onDidUpdate(callback))
     } else {
       this.imageSizeStatus.style.display = 'none'
     }

--- a/lib/image-editor-view.js
+++ b/lib/image-editor-view.js
@@ -43,6 +43,20 @@ export default class ImageEditorView {
       this.emitter.emit('did-load')
     }
 
+    new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        if (mutation.attributeName === 'src') {
+          this.refs.image.onload = () => {
+            this.refs.image.onload = null
+            this.originalHeight = this.refs.image.naturalHeight
+            this.originalWidth = this.refs.image.naturalWidth
+            this.imageSize = fs.statSync(this.editor.getPath()).size
+            this.emitter.emit('did-update')
+          }
+        }
+      }
+    }).observe(this.refs.image, { attributes: true })
+
     this.disposables.add(atom.tooltips.add(this.refs.whiteTransparentBackgroundButton, {title: 'Use white transparent background'}))
     this.disposables.add(atom.tooltips.add(this.refs.blackTransparentBackgroundButton, {title: 'Use black transparent background'}))
     this.disposables.add(atom.tooltips.add(this.refs.transparentTransparentBackgroundButton, {title: 'Use transparent background'}))
@@ -125,6 +139,10 @@ export default class ImageEditorView {
 
   updateImageURI () {
     this.refs.image.src = `${this.editor.getEncodedURI()}?time=${Date.now()}`
+  }
+
+  onDidUpdate (callback) {
+    return this.emitter.on('did-update', callback)
   }
 
   // Zooms the image out by 25%.


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

When an image is reloaded from disc, it assigns a new value to `src` with the current date. However, this does not trigger the `on-load` callback. To be able to track this change, a `MutationObserver` is required to again listen for the `on-load` after the fact, to then fire an update. The status bar thus listens to this update and calculates the sizes again.

### Alternate Designs

I am not aware of a different method to achieve this

### Benefits

The status bar is updated again

### Possible Drawbacks

I could not write a test for this. First of all, when I would copy `displays the size of the image` as is in the spec, it would throw `TypeError: Cannot read property 'textContent' of null`. For some reason there is state left over after the `beforeEach`, but I could not track down why.

### Applicable Issues

Fixes #105
