### PR TITLE
Restore ability to display info for pending pane items

### DIFF
--- a/lib/image-editor-status-view.js
+++ b/lib/image-editor-status-view.js
@@ -18,7 +18,7 @@ export default class ImageEditorStatusView {
 
     this.attach()
 
-    this.disposables.add(atom.workspace.onDidChangeActivePaneItem(() => { this.updateImageSize() }))
+    this.disposables.add(atom.workspace.getCenter().onDidChangeActivePaneItem(() => { this.updateImageSize() }))
   }
 
   attach () {
@@ -41,7 +41,7 @@ export default class ImageEditorStatusView {
       this.imageLoadDisposable.dispose()
     }
 
-    const editor = atom.workspace.getActivePaneItem()
+    const editor = atom.workspace.getCenter().getActivePaneItem()
     if (editor instanceof ImageEditor) {
       this.editorView = editor.view
       if (this.editorView.loaded) {
@@ -49,7 +49,7 @@ export default class ImageEditorStatusView {
       }
 
       this.imageLoadDisposable = this.editorView.onDidLoad(() => {
-        if (editor === atom.workspace.getActivePaneItem()) {
+        if (editor === atom.workspace.getCenter().getActivePaneItem()) {
           this.getImageSize(this.editorView)
         }
       })

--- a/lib/image-editor.js
+++ b/lib/image-editor.js
@@ -67,6 +67,10 @@ export default class ImageEditor {
     }
   }
 
+  getAllowedLocations () {
+    return ['center']
+  }
+
   // Retrieves the filename of the open file.
   //
   // This is `'untitled'` if the file is new and not saved to the disk.

--- a/lib/image-editor.js
+++ b/lib/image-editor.js
@@ -37,7 +37,7 @@ export default class ImageEditor {
   }
 
   terminatePendingState () {
-    if (this.isEqual(atom.workspace.getActivePane().getPendingItem())) {
+    if (this.isEqual(atom.workspace.getCenter().getActivePane().getPendingItem())) {
       this.emitter.emit('did-terminate-pending-state')
     }
   }

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -8,7 +8,7 @@ module.exports =
     @statusViewAttached = null
     @disposables = new CompositeDisposable
     @disposables.add atom.workspace.addOpener(openURI)
-    @disposables.add atom.workspace.onDidChangeActivePaneItem => @attachImageEditorStatusView()
+    @disposables.add atom.workspace.getCenter().onDidChangeActivePaneItem => @attachImageEditorStatusView()
 
   deactivate: ->
     @statusViewAttached?.destroy()
@@ -19,7 +19,7 @@ module.exports =
   attachImageEditorStatusView: ->
     return if @statusViewAttached
     return unless @statusBar?
-    return unless atom.workspace.getActivePaneItem() instanceof ImageEditor
+    return unless atom.workspace.getCenter().getActivePaneItem() instanceof ImageEditor
 
     ImageEditorStatusView = require './image-editor-status-view'
     @statusViewAttached = new ImageEditorStatusView(@statusBar)

--- a/spec/image-editor-spec.coffee
+++ b/spec/image-editor-spec.coffee
@@ -73,6 +73,20 @@ describe "ImageEditor", ->
         item.terminatePendingState()
         expect(pendingSpy).not.toHaveBeenCalled()
 
+  describe "::getAllowedLocations", ->
+    it "ensures that ImageEditor opens in workspace center", ->
+      waitsForPromise ->
+        atom.packages.activatePackage('image-view')
+
+      runs ->
+        atom.workspace.open(path.join(__dirname, 'fixtures', 'binary-file.png'), {location: 'right'})
+
+      waitsFor ->
+        atom.workspace.getActivePaneItem() instanceof ImageEditor
+
+      runs ->
+        expect(atom.workspace.getCenter().getActivePaneItem().getTitle()).toBe 'binary-file.png'
+
   describe "when the image gets reopened", ->
     beforeEach ->
       waitsForPromise ->


### PR DESCRIPTION
Following the approach used in https://github.com/atom/status-bar/pull/195 and https://github.com/atom/github/pull/905, this PR updates this package to expect any `ImageEditor` pane items to exist in the workspace center.

### Alternate Designs

See https://github.com/atom/atom/pull/14695.

### Benefits

Fixes https://github.com/atom/image-view/issues/132.

The package will be able to display the image dimensions and file size for pending pane items as the user navigates the tree-view.

### Possible Drawbacks

See https://github.com/atom/atom/pull/14695.

### Applicable Issues

- https://github.com/atom/image-view/issues/132
- https://github.com/atom/atom/issues/14648
- https://github.com/atom/status-bar/issues/194

### Demo

#### Before

![before](https://user-images.githubusercontent.com/2988/28192495-8f6eb8e4-6804-11e7-9276-a9492cb482b6.gif)

#### After

![after](https://user-images.githubusercontent.com/2988/28192494-8f6bfcf8-6804-11e7-94bb-a4e725494df5.gif)
