### PR TITLE
Add default background config

### DIFF
--- a/lib/image-editor-view.js
+++ b/lib/image-editor-view.js
@@ -42,6 +42,8 @@ export default class ImageEditorView {
       this.originalWidth = this.refs.image.naturalWidth
       this.loaded = true
       this.refs.image.style.display = ''
+      defaultBackgroundColor = atom.config.get('image-view.defaultBackgroundColor')
+      this.refs.imageContainer.setAttribute('background', defaultBackgroundColor)
       this.emitter.emit('did-load')
     }
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -4,6 +4,12 @@ ImageEditor = require './image-editor'
 {CompositeDisposable} = require 'atom'
 
 module.exports =
+  config:
+    defaultBackgroundColor:
+      type: "string"
+      enum: ["white", "black", "transparent"]
+      default: "transparent"
+
   activate: ->
     @statusViewAttached = null
     @disposables = new CompositeDisposable


### PR DESCRIPTION
### Description of the Change

Adds a default background color config. Setting this makes all new panes open with that background colour (as opposed to the original hard set value of `transparent`).

The colours were chosen to align with those offered by the buttons in the image pane. The list order also aligns with the order of these buttons.

The default value matches the existing behaviour, so users will not notice unless they change it themselves.

It does this by setting the background colour the same way as clicking one of the colour buttons would, but as the image is being loaded.

### Alternate Designs

A string input could allow custom colour choices. Enumerable is simpler and easier to understand though.

The exact wording of the config can be changed, and tests can be added if wanted.

### Benefits

Users don't need to change the background colour when opening an image quite as frequently as they otherwise would.

### Possible Drawbacks

None. The change will not affect users who didn't need it.

### Applicable Issues

https://github.com/atom/image-view/pull/80

Don't quite know why this was closed and labelled `wontfix`; seems to be some sort of bug. It's changes look a lot more complicated though, whereas this PR just sets the background colour the same way as clicking one of the colour buttons would.