### PR TITLE
Remove global background colour variable

### DIFF
--- a/lib/image-editor-view.js
+++ b/lib/image-editor-view.js
@@ -42,8 +42,8 @@ export default class ImageEditorView {
       this.originalWidth = this.refs.image.naturalWidth
       this.loaded = true
       this.refs.image.style.display = ''
-      defaultBackgroundColor = atom.config.get('image-view.defaultBackgroundColor')
-      this.refs.imageContainer.setAttribute('background', defaultBackgroundColor)
+      this.defaultBackgroundColor = atom.config.get('image-view.defaultBackgroundColor')
+      this.refs.imageContainer.setAttribute('background', this.defaultBackgroundColor)
       this.emitter.emit('did-load')
     }
 


### PR DESCRIPTION
My last PR added a choice for default background colour. As a global variable :unamused:.

This PR changes the value to a property of the `ImageEditorView`. I would have made it just local, but it might be more useful this way.

I could have moved it up to the main body of the constructor, but I don't think it really matters.