### PR TITLE
emit `destroy` event like promised

### DIFF
--- a/lib/image-editor.js
+++ b/lib/image-editor.js
@@ -83,6 +83,7 @@ export default class ImageEditor {
     if (this.view) {
       this.view.destroy()
     }
+    this.emitter.emit('did-destroy')
   }
 
   getAllowedLocations () {


### PR DESCRIPTION
### Description of the Change

Make it emit the `did-destroy` event like the inline doc comments say can be expected. I don't actually know how someone would access that method, but seems reasonable to have (and is consistent with many other API methods in Atom).


### Applicable Issues

Fixes #177
