### PR TITLE
Disable user select

### DIFF
--- a/styles/image-view.less
+++ b/styles/image-view.less
@@ -7,6 +7,7 @@
   display: flex;
   flex-direction: column;
   background-color: @pane-item-background-color;
+  user-select: none;
 
 
   // Image Controls -------------------


### PR DESCRIPTION
### Description of the Change

Prevents the image from turning blue when the user drags across or click the buttons too quickly/much.


### Possible Drawbacks

I don't think anyone needs selection, and raised #181 for a discussion. One reply and 14 hours later, here we are.

For reference, this will allow you to select again (paste in your `styles.less` file):
```less
.image-view {
  user-select: auto;
}
```

### Applicable Issues

Closes #181
