### PR TITLE
Use whole pixel values when zooming

### DIFF
--- a/lib/image-editor-view.js
+++ b/lib/image-editor-view.js
@@ -213,8 +213,8 @@ class ImageEditorView {
     }
 
     const factor = this.steps[percentageStep]
-    const newWidth = this.originalWidth * factor
-    const newHeight = this.originalHeight * factor
+    const newWidth = Math.round(this.originalWidth * factor)
+    const newHeight = Math.round(this.originalHeight * factor)
     const percent = Math.max(1, Math.round((newWidth / this.originalWidth) * 100))
 
     // Switch to pixelated rendering when image is bigger than 200%


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Pixel values should be whole to begin with, and this also solves the failing specs on my machine.

### Alternate Designs

None.

### Benefits

No more fractional heights and widths.

### Possible Drawbacks

None, as the tests were already expecting whole values.

### Applicable Issues

None.